### PR TITLE
Add git_archival configuration for hatch-vcs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
This allows installing the project from a git archive without extra steps. I am currently using wait-for-copr from Git, as it's not published to PyPI.

Ref: https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives

<!-- release notes footer -->

RELEASE NOTES BEGIN

Add git_archival configuration to enable installing the project from a `git archive` tarball.

RELEASE NOTES END
